### PR TITLE
Update dependencies on the CI & dev env

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -88,9 +88,9 @@ jobs:
           python-version: 3.7
       - name: Build package
         run: |
-          pip install wheel jupyter-packaging jupyterlab>=3
+          pip install wheel "jupyter_packaging~=0.10,<2" "jupyterlab~=3.1"
           python setup.py sdist bdist_wheel
-          # Don't publish a tar.gz file over 1MB  (Issue #730)
+          # Don't publish a tar.gz file over 1MB  (Issue jupytext/730)
           if (($(wc -c < dist/*.tar.gz) > 1000000)); then exit 1; fi
           # node_modules should not be in the package
           if (($(tar -tf dist/*.tar.gz | grep node_modules | wc -l)>0)); then echo "node_modules should not be included" && exit 1; fi

--- a/environment.yml
+++ b/environment.yml
@@ -2,10 +2,10 @@ name: jupyterlab-itables-dev
 channels:
   - defaults
 dependencies:
-  - jupyterlab>=3.0.0,<4.0.0
+  - jupyterlab>=3.1,<4.0
   - setuptools>=40.8.0
   - wheel
   - pip
   - nodejs>=12
   - pip:
-    - jupyter_packaging>=0.7.9,<0.8.0
+    - jupyter_packaging>=0.10,<2


### PR DESCRIPTION
Relates to #5 

With this PR we will use the same build dependencies on the CI & dev environment than in pyproject.toml.